### PR TITLE
[Bug] decode base64 encoded function body

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,10 +1,10 @@
-FROM public.ecr.aws/lambda/nodejs:16 as builder
+FROM public.ecr.aws/lambda/nodejs:18 as builder
 WORKDIR /usr/app
 COPY package.json index.ts  ./
 RUN npm install
 RUN npm run build
 
-FROM public.ecr.aws/lambda/nodejs:16
+FROM public.ecr.aws/lambda/nodejs:18
 WORKDIR ${LAMBDA_TASK_ROOT}
 COPY --from=builder /usr/app/dist/* ./
 CMD ["index.handler"]

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,9 +1,18 @@
 import { Context, APIGatewayProxyResult, APIGatewayEvent } from 'aws-lambda';
+import { Buffer } from "buffer";
+
+const decode = (str: string):string => Buffer.from(str, 'base64').toString('binary');
 
 export const handler = async (event: APIGatewayEvent, _context: Context): Promise<APIGatewayProxyResult> => {
     // Event will contain things passed via request as --data
     console.log("Example of Environment variable access:", process.env.TEST_VAR)
-    const txHash = event.body? JSON.parse(event.body).txHash : (event as any).txHash;
+    let txHash: string;
+    if (event.body !== null) {
+        txHash = JSON.parse(decode(event.body)).txHash;
+    } else {
+        txHash = (event as any).txHash;
+    }
+    // const txHash = event.body? JSON.parse(event.body).txHash : (event as any).txHash;
 
     return {
         statusCode: 200,

--- a/python/app.py
+++ b/python/app.py
@@ -4,6 +4,11 @@ import os
 from src.db_client import PgClient
 
 
+import base64
+
+
+
+
 def handler(event, context):
     """
     Strange issue where locally and when testing in 
@@ -17,7 +22,8 @@ def handler(event, context):
     
     # TODO - this is a hacky way of handling both event types.
     if "body" in event:
-        event = json.loads(event["body"])
+        encoded_string = event["body"]
+        event = json.loads(base64.b64decode(encoded_string))
     print("Body", event)
     
     db = PgClient(os.environ.get("DATABASE_URL"))


### PR DESCRIPTION
When calling function URL from outside, the content gets base64 encoded.

Unfortunately I have not been able to publish the new images.
